### PR TITLE
Fix Check.HasCorrectLength

### DIFF
--- a/src/EnsuredOutcomes/Check.cs
+++ b/src/EnsuredOutcomes/Check.cs
@@ -50,7 +50,7 @@ namespace EnsuredOutcomes
 
             // the length of a null string is 0;
             int length = value?.Length ?? 0;
-            return length < minimumLength || length > maximumLength;
+            return length >= minimumLength && length <= maximumLength;
         }
 
         /// <summary>


### PR DESCRIPTION
Hello!

This is correct return true if the length of value is between the given range; otherwise, false.